### PR TITLE
HealthKitから歩数を取得する

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "SamplePlugin",
+    platforms: [
+        .iOS(.v15)
+    ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/SamplePluginApp/SamplePluginApp.xcodeproj/project.pbxproj
+++ b/SamplePluginApp/SamplePluginApp.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		CE1E4E412A38A86200236679 /* SamplePluginApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SamplePluginApp.entitlements; sourceTree = "<group>"; };
 		CE39FAEC2A2F21060043778A /* SamplePluginApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SamplePluginApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE39FAEF2A2F21060043778A /* SamplePluginAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SamplePluginAppApp.swift; sourceTree = "<group>"; };
 		CE39FAF12A2F21060043778A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -54,6 +55,7 @@
 		CE39FAEE2A2F21060043778A /* SamplePluginApp */ = {
 			isa = PBXGroup;
 			children = (
+				CE1E4E412A38A86200236679 /* SamplePluginApp.entitlements */,
 				CE39FAEF2A2F21060043778A /* SamplePluginAppApp.swift */,
 				CE39FAF12A2F21060043778A /* ContentView.swift */,
 				CE39FAF32A2F21070043778A /* Assets.xcassets */,
@@ -277,6 +279,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = SamplePluginApp/SamplePluginApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SamplePluginApp/Preview Content\"";
@@ -306,6 +309,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = SamplePluginApp/SamplePluginApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SamplePluginApp/Preview Content\"";

--- a/SamplePluginApp/SamplePluginApp.xcodeproj/project.pbxproj
+++ b/SamplePluginApp/SamplePluginApp.xcodeproj/project.pbxproj
@@ -286,6 +286,7 @@
 				DEVELOPMENT_TEAM = 8KC4L2BAV2;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "read HealthKit Data";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -316,6 +317,7 @@
 				DEVELOPMENT_TEAM = 8KC4L2BAV2;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "read HealthKit Data";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/SamplePluginApp/SamplePluginApp/ContentView.swift
+++ b/SamplePluginApp/SamplePluginApp/ContentView.swift
@@ -9,18 +9,19 @@ import SwiftUI
 import SamplePlugin
 
 struct ContentView: View {
-    @State var number = 0
+    @State var steps = 0
     
     var body: some View {
         VStack {
-            Text("\(number)")
+            Text("\(steps)")
                 .font(.largeTitle)
                 .fontWeight(.bold)
                 .foregroundColor(.accentColor)
 
-
             Button(action: {
-                number = Int(sample_plugin_helloworld())
+                HealthKitData().getStepsToday { steps in
+                    self.steps = steps
+                }
             }) {
                 Text("Tap me!")
                     .font(.title)
@@ -32,6 +33,11 @@ struct ContentView: View {
             }
         }
         .padding()
+        .onAppear {
+            HealthKitData().authorize { success in
+                print("authorize: \(success)")
+            }
+        }
     }
 }
 

--- a/SamplePluginApp/SamplePluginApp/SamplePluginApp.entitlements
+++ b/SamplePluginApp/SamplePluginApp/SamplePluginApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.healthkit</key>
+	<true/>
+	<key>com.apple.developer.healthkit.access</key>
+	<array/>
+</dict>
+</plist>

--- a/Sources/SamplePlugin/HealthKitData.swift
+++ b/Sources/SamplePlugin/HealthKitData.swift
@@ -1,0 +1,51 @@
+import Foundation
+import HealthKit
+
+public class HealthKitData {
+    public init() {}
+
+    // HealthKitのデータにアクセスするためにユーザーの許可を求める。
+    // 複数回呼び出しても構わない。(すでに許可済みの場合にはcompletionでtrueが渡される)
+    public func authorize(completion: @escaping (Bool) -> Void) {
+        guard HKHealthStore.isHealthDataAvailable() else {
+            print("is not health data available")
+            completion(false)
+            return
+        }
+
+        let typesToRead = Set([HKObjectType.quantityType(forIdentifier: .stepCount)!])
+
+        HKHealthStore().requestAuthorization(toShare: nil, read: typesToRead) { (success, error) in
+            if let error {
+                print("requestAuthorization failed. error: \(error.localizedDescription)")
+                completion(false)
+                return
+            }
+            // successはリクエストが成功したかどうか。
+            // ユーザーが許可したことを示す値ではない。
+            completion(success)
+        }
+    }
+
+    public func getStepsToday(completion: @escaping (Int) -> Void) {
+        let now = Date()
+        let startOfDay = Calendar.current.startOfDay(for: now)
+        let type = HKSampleType.quantityType(forIdentifier: .stepCount)!
+        let predicate = HKQuery.predicateForSamples(withStart: startOfDay, end: now)
+        let query = HKStatisticsQuery(quantityType: type, quantitySamplePredicate: predicate, options: .cumulativeSum) { (query, statistics, error) in
+            // The results come back on an anonymous background queue.
+            DispatchQueue.main.async {
+                guard let statistics else {
+                    print("getStepsToday failed. error: \(error?.localizedDescription ?? "nil")")
+                    completion(0)
+                    return
+                }
+
+                let sum = statistics.sumQuantity()
+                let steps = sum?.doubleValue(for: HKUnit.count())
+                completion(Int(steps ?? 0))
+            }
+        }
+        HKHealthStore().execute(query)
+    }
+}


### PR DESCRIPTION
## 本PRについて

- HealthKitにアクセスして歩数を取得する機能を作成
- 取得した歩数をNativeアプリで表示

## authorizeのやり方
https://developer.apple.com/documentation/healthkit/authorizing_access_to_health_data

HKHealthStore
https://developer.apple.com/documentation/healthkit/hkhealthstore

requestAuthorization
https://developer.apple.com/documentation/healthkit/hkhealthstore/1614152-requestauthorization

## HKStatisticsQueryの使い方
必要なのは
- quantityType
- quantitySamplePredicate
- options
- completionHandler

以下を参考に調べた。
https://developer.apple.com/documentation/healthkit/queries/executing_statistical_queries

#### HKQuantityType
https://developer.apple.com/documentation/healthkit/hkquantitytype

https://developer.apple.com/documentation/healthkit/hkobjecttype/1615298-quantitytype
https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier
ここから当てはまるtypeを選ぶ。
今回は歩数のため number of steps のstepCount

#### quantitySamplePredicate
参考文献より、HKQueryを使えばいいとわかる
HKQuery 
https://developer.apple.com/documentation/healthkit/hkquery

https://developer.apple.com/documentation/healthkit/hkquery#1664479
参考文献通り predicateForSamplesを使えば良さそう

predicateForSamplesのoptionsに関しては厳密に測定するためのものみたいだが、
いまいち使い道がよくわからなかったため省略

日付は以下の記事を参考に書いた
https://qiita.com/tamadeveloper/items/8e4f68d586cc5b0f9a5a

#### options HKStatisticsOptionsQuery
https://developer.apple.com/documentation/healthkit/hkstatisticsoptions
completionHandlerでやりたいことによってここのoptionを決める。
合計するときは .cumlativeSumを指定

#### completionHandler

第二引数はstatistics
https://developer.apple.com/documentation/healthkit/hkstatistics

> When requesting data from a statistics object, your request must match the options you used when creating the query. For example, if you create a query using the [discreteAverage](https://developer.apple.com/documentation/healthkit/hkstatisticsoptions/1615371-discreteaverage) option, you must access the results using the [averageQuantity()](https://developer.apple.com/documentation/healthkit/hkstatistics/1615386-averagequantity) method.

合計なのでsumQuantityを使う。
sumQuantity 
https://developer.apple.com/documentation/healthkit/hkstatistics/1615680-sumquantity

返ってきたHKQuantityをdoubleValueでDoubleにする。
単位はcountした歩数なのでcount()で指定
https://developer.apple.com/documentation/healthkit/hkunit#1677248

そのあとIntに変換する。

## 認証状況の確認について
以下でできそうだが必要になるまではやらなくてもいいと判断。
https://developer.apple.com/documentation/healthkit/hkauthorizationstatus


